### PR TITLE
Fixed `lint` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,16 @@
  */
 var es = require('event-stream'),
 	htmlmin = require('html-minifier'),
+	HTMLLint = require('html-minifier/src/htmllint').HTMLLint,
 	gutil = require('gulp-util');
 module.exports = function (options) {
 	options = options || {
 		showStack: false,
 	};	
+
+	if (options.lint) {
+		options.lint = new HTMLLint();
+	}
 	// snipets stripPath, toArray & unixify based on gulp-inject
 	// https://github.com/klei/gulp-inject/blob/master/index.js
 	function ignorePath (basedir, filepath) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "event-stream": "^3.0.20",
     "gulp-util": "^2.2.20",
-    "html-minifier": "^0.6.9"
+    "html-minifier": "^1.0.1"
   },
   "keywords": [
     "gulpplugin",

--- a/test/test.js
+++ b/test/test.js
@@ -80,6 +80,14 @@ describe('gulp-html-minifier HTML minifier', function () {
 		});
 		stream.write(fakeFile);
 	});
+	it('should return file.contents as a buffer with lint option', function (done) {
+		var stream = minify({ lint: true });
+		stream.once('data', function(newFile){
+			expect(newFile.contents).to.be.an.instanceOf(Buffer);
+			done();
+		});
+		stream.write(fakeFile);
+	});
 	it('should throw a gulp error', function(done) {
 		var stream = minify();
 		stream.on('error', function (err) {


### PR DESCRIPTION
I got a crash when I wanted to use this gulp plugin with `lint` option.

I took a look to html-minifier and I found that minify function need that `lint` option must be an object which perform the operation than a boolean.

html-minifier doc show `lint` option as a boolean because the CLI client checks [the option and replace the boolean by the instance of the HTMLLint object](https://github.com/kangax/html-minifier/blob/v1.0.1/cli.js#L278L280) before passing [the options to minifier object](https://github.com/kangax/html-minifier/blob/v1.0.1/cli.js#L163).

Because this plugin pass the options directly to the minifier object than using the CLI, due the gulp needs, is required to make that replacement as CLI does. 

This is a proposed fix for the mentioned above.

On the other hand I upgraded the version of html-minifier to the last version available; I wanted to see the [CHANGELOG](https://github.com/kangax/html-minifier/blob/gh-pages/CHANGELOG.md) to know the breaking changes and see if it could be done with no issues, however CHANGELOG hasn't contain the changes the last versions created.
